### PR TITLE
Add quick access services via Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Discover API controllers for Kites
 
 * Auto Discover: models, services and controllers
 * Auto generate RESTful API with basic CRUD operations
-* Auto generate user-defined API actions 
+* Auto generate user-defined API actions
+* Quick access models, services via Proxy
 
 Extension Options
 =================
@@ -43,6 +44,41 @@ Auto discover mode, just install the extension as a dependency:
 
 ```bash
 npm install @kites/api
+```
+
+## APIs and Events
+
+1. Access models and services
+
+* `kites.model([model_name])` - get model has initialized
+* `kites.service([service_name])` - get service has initialized
+* `kites.controller([controller_name])` - get controller has initialized
+
+Example:
+
+```js
+// Obtain models and service by:
+var userModel = kites.model('user');
+var userService = kites.service('user');
+
+// Or quick access these one via proxy
+var userModel = kites.db.user
+var userService = kites.sv.user
+```
+
+2. Listen event model initialized
+
+* `apiBeforeConfigure`: Before kites api configure
+* `apiModelRegistered`: All models loaded in kites system
+* `apiModelInitialized`: All models registered and initialized
+* `apiConfigure`: All models, services and controllers initialized
+
+Example:
+
+```js
+kites.on('apiModelInitialized', (kites) => {
+    console.log(kites.models);
+})
 ```
 
 # License

--- a/lib/main.js
+++ b/lib/main.js
@@ -45,10 +45,29 @@ module.exports = function (kites, definition) {
         kites.emit('apiModelInitialized', kites);
     });
 
+    // Notify
+    kites.emit('apiBeforeConfigure', kites);
+
+    /**
+     * Alias to quick access models
+     */
     kites.db = new Proxy({}, {
         get (obj, prop) {
             if (typeof prop === 'string') {
-                return kites.model(prop);
+                return kites.model(prop.toLowerCase());
+            } else {
+                return obj[prop];
+            }
+        }
+    });
+
+    /**
+     * Alias to quick access services
+     */
+    kites.sv = new Proxy({}, {
+        get (obj, prop) {
+            if (typeof prop === 'string') {
+                return kites.service(prop.toLowerCase());
             } else {
                 return obj[prop];
             }
@@ -264,4 +283,5 @@ module.exports = function (kites, definition) {
         return _newCtrl;
     });
 
+    kites.emit('apiConfigure', kites);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kites/api",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Abstract API Discovery for Kites",
   "main": "index.js",
   "scripts": {

--- a/test/kites-api.js
+++ b/test/kites-api.js
@@ -7,7 +7,7 @@ var kitesExpress = require('@kites/express');
 var kitesApi = require('../index');
 
 test('kites api test', function (t) {
-    t.plan(8);
+    t.plan(9);
 
     engine({
             logger: {
@@ -24,7 +24,8 @@ test('kites api test', function (t) {
         .use(kitesApi())
         .ready((kites) => {
             // util
-            t.equal(kites.db.user.modelName, 'user', 'Access user model name via proxy (db)');
+            t.equal(kites.db.user.modelName, 'user', 'Access user model via proxy (db)');
+            t.equal(kites.sv.uSer.name, 'user', 'Access user service via proxy (sv)');
         })
         .init().then((kites) => {
             // make requests


### PR DESCRIPTION
* Add quick access models via Proxy (db)
* Add quick access services via Proxy (sv)
* Emit event before and after `kites-api` initializing.