### PR TITLE
Add option to useBaseModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Discover API controllers for Kites
 [![Join the chat at https://gitter.im/nodevn/kites](https://badges.gitter.im/nodevn/kites.svg)](https://gitter.im/nodevn/kites)
 [![npm version](https://img.shields.io/npm/v/@kites/api.svg?style=flat)](https://www.npmjs.com/package/@kites/api)
 [![npm downloads](https://img.shields.io/npm/dm/@kites/api.svg)](https://www.npmjs.com/package/@kites/api)
+[![Travis](https://travis-ci.org/vunb/kites-api.svg?branch=stable)](https://travis-ci.org/vunb/kites-api)
 
 # Features
 

--- a/lib/base/controller.js
+++ b/lib/base/controller.js
@@ -1,11 +1,4 @@
 'use strict';
-var path = require('path'),
-    fs = require('fs')
-    // , BaseService = require('../services/BaseModelService')
-    ,
-    baseUtil = require('./util'),
-    rootDir = process.cwd(),
-    logger = console;
 
 class BaseController {
 
@@ -44,7 +37,6 @@ class BaseController {
 
     read(req, res, next) {
         var id = req.params.id;
-        this.logInfo('Read data model: ' + this.name);
         if (!/^[-0-9a-fA-F]{1,36}$/.test(id)) {
             // Yes, it's not a valid ObjectId, otherwise proceed with `findById` call.
             return res.badRequest('ObjectId is not valid: ' + id);

--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -8,6 +8,10 @@ class BaseModel {
         this.connections = kites.dataSource.connections;
     }
 
+    get collection() {
+        return this.name;
+    }
+
     get database() {
         this.logger.debug('get database connection: ' + this.options.connection);
         return this.options.connection;
@@ -20,7 +24,7 @@ class BaseModel {
             throw `Data source ${this.database} is not available!`;
         }
 
-        this.instance = this.connections[this.database].define(this.name, this.schema);
+        this.instance = this.connections[this.database].define(this.collection, this.schema);
         return this.instance;
     }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -134,6 +134,11 @@ module.exports = function (kites, definition) {
 
         var DerivedModel = require(modelFileName);
 
+        if (!DerivedModel || !DerivedModel.prototype) {
+            kites.logger.error(`Model definition is invalid: [${modelName}]!`);
+            return null;
+        }
+
         Object.setPrototypeOf(DerivedModel.prototype, BaseModel.prototype);
         Object.defineProperties(DerivedModel.prototype, {
             kites: {
@@ -182,6 +187,11 @@ module.exports = function (kites, definition) {
         var DerivedService = require(serviceFileName);
         kites.logger.debug(`register service (${serviceName}):`, serviceFileName);
 
+        if (!DerivedService || !DerivedService.prototype) {
+            kites.logger.error(`Service definition is invalid: [${modelName}]!`);
+            return null;
+        }
+
         Object.setPrototypeOf(DerivedService.prototype, BaseService.prototype);
         Object.defineProperties(DerivedService.prototype, {
             kites: {
@@ -226,7 +236,7 @@ module.exports = function (kites, definition) {
         var ctrlName = path.basename(ctrlFileName).replace(/controller.js$/i, '').toLowerCase();
         var DerivedController = require(ctrlFileName);
 
-        if (!DerivedController.prototype) {
+        if (!DerivedController || !DerivedController.prototype) {
             kites.logger.error('invalid controller: ' + ctrlFileName);
             return null;
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kites/api",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Abstract API Discovery for Kites",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kites/api",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Abstract API Discovery for Kites",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kites/api",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Abstract API Discovery for Kites",
   "main": "index.js",
   "scripts": {

--- a/test/api/models/UserClass.js
+++ b/test/api/models/UserClass.js
@@ -3,8 +3,8 @@ class UserClassModel {
     /**
      * Table or collection name
      */
-    get name() {
-        return 'UserClass';
+    get collection() {
+        return 'UserClass_TableOrCollectionName';
     }
 
     /**

--- a/test/kites-api.js
+++ b/test/kites-api.js
@@ -7,7 +7,7 @@ var kitesExpress = require('@kites/express');
 var kitesApi = require('../index');
 
 test('kites api test', function (t) {
-    t.plan(9);
+    t.plan(10);
 
     engine({
             logger: {
@@ -24,7 +24,8 @@ test('kites api test', function (t) {
         .use(kitesApi())
         .ready((kites) => {
             // util
-            t.equal(kites.db.user.modelName, 'user', 'Access user model via proxy (db)');
+            t.equal(kites.db.user.modelName, 'user', 'Access user model via proxy (db.1)');
+            t.equal(kites.db.UserClass.modelName, 'UserClass_TableOrCollectionName', 'Access user model via proxy (db.2)');
             t.equal(kites.sv.uSer.name, 'user', 'Access user service via proxy (sv)');
         })
         .init().then((kites) => {


### PR DESCRIPTION
- Add `.editorconfig` convention.
- Add option to use base models, services, controllers or not.
- Safe discover models, services and controllers.